### PR TITLE
Fixed: set PmntDeclined for failure cases and PmntProposed for require action (#1t86kje)

### DIFF
--- a/service/Stripe/StripePaymentServices.xml
+++ b/service/Stripe/StripePaymentServices.xml
@@ -392,12 +392,16 @@ along with this software (see the LICENSE.md file). If not, see
                     <if condition="'requires_capture'.equals(responseMap.errorInfo.status)">
                         <set field="payment.statusId" value="PmntAuthorized"/>
                         <else-if condition="'succeeded'.equals(responseMap.errorInfo.status)">
-                            <!-- case for requires_action -->
                             <set field="payment.statusId" value="PmntConfirmed"/>
                         </else-if>
                         <else-if condition="'requires_action'.equals(responseMap.errorInfo.status)">
-                            <set field="payment.statusId" value="PmntPromised"/>
+                            <!-- case for requires_action TODO Handle it in a better way, As currently we do handle it kept status to declined so that capturing is avoided -->
+                            <set field="payment.statusId" value="PmntDeclined"/>
                         </else-if>
+                        <else>
+                            <!-- Failure cases -->
+                            <set field="payment.statusId" value="PmntDeclined" />
+                        </else>
                     </if>
                     <entity-update value-field="payment"/>
                 </then>


### PR DESCRIPTION
By default, payment is in  promised status when payment fails it should be changed to valid status PmntDeclined. Additionally, when the payment require extra authentication changed it PmntDeclined as this needs to be handled and should not be further  captured